### PR TITLE
Pin 3rd party actions

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -22,10 +25,12 @@ jobs:
           - '12'
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: Using Node version ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -13,7 +13,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
       contents: write
       packages: write
 
@@ -21,12 +20,12 @@ jobs:
 
     - name: Parse semver string
       id: semver_parser 
-      uses: booxmedialtd/ws-action-parse-semver@v1
+      uses: booxmedialtd/ws-action-parse-semver@7784200024d6b3fc01253e617ec0168daf603de3 # v1.4.7
       with:
         input_string: ${{ inputs.version }}-pre-release
 
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Install Node.js
       uses: actions/setup-node@v3
@@ -36,7 +35,9 @@ jobs:
         scope: '@openpass'
 
     - name: Set version for deploy
-      run: npm version ${{ steps.semver_parser.outputs.fullversion }} --no-git-tag-version --allow-same-version
+      run: npm version "${VERSION}" --no-git-tag-version --allow-same-version
+      env:
+        VERSION: ${{ steps.semver_parser.outputs.fullversion }}
 
     - name: NPM Install
       run: npm install --also=dev
@@ -53,7 +54,9 @@ jobs:
       run: |
         git add package.json
         git add package-lock.json
-        git commit -m "Releasing version: ${{ steps.semver_parser.outputs.fullversion }}"
+        git commit -m "Releasing version: ${VERSION}"
+      env:
+        VERSION: ${{ steps.semver_parser.outputs.fullversion }}
 
     - name: NPM Publish
       run: npm publish
@@ -61,13 +64,13 @@ jobs:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
     - name: Create Release Tag
-      uses: rickstaa/action-create-tag@v1
+      uses: rickstaa/action-create-tag@a1c7777fcb2fee4f19b0f283ba888afa11678b72 # v1.7.2
       with:
         tag: "v${{ steps.semver_parser.outputs.fullversion }}"
         message: "Release v${{ steps.semver_parser.outputs.fullversion }}"
 
     - name: GitHub Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
       with:
         generate_release_notes: true
         tag_name: v${{ steps.semver_parser.outputs.fullversion }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,7 +2,10 @@ name: Pull request build and test
 
 on:
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
+
+permissions:
+  contents: read
 
 jobs:
   build:
@@ -22,10 +25,12 @@ jobs:
           - '12'
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: Using Node version ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,6 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      id-token: write
       contents: write
       packages: write
 
@@ -22,12 +21,12 @@ jobs:
 
     - name: Parse semver string
       id: semver_parser 
-      uses: booxmedialtd/ws-action-parse-semver@v1
+      uses: booxmedialtd/ws-action-parse-semver@7784200024d6b3fc01253e617ec0168daf603de3 # v1.4.7
       with:
         input_string: ${{ inputs.version }}
 
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal access token.
 
@@ -39,7 +38,9 @@ jobs:
         scope: '@openpass'
 
     - name: Set version for deploy
-      run: npm version ${{ steps.semver_parser.outputs.fullversion }} --no-git-tag-version --allow-same-version
+      run: npm version "${VERSION}" --no-git-tag-version --allow-same-version
+      env:
+        VERSION: ${{ steps.semver_parser.outputs.fullversion }}
 
     - name: NPM Install 
       run: npm install --also=dev
@@ -56,7 +57,9 @@ jobs:
       run: |
         git add package.json
         git add package-lock.json
-        git commit -m "Releasing version: ${{ steps.semver_parser.outputs.fullversion }}"
+        git commit -m "Releasing version: ${VERSION}"
+      env:
+        VERSION: ${{ steps.semver_parser.outputs.fullversion }}
 
     - name: NPM Publish
       run: npm publish
@@ -64,18 +67,18 @@ jobs:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
     - name: Push changes
-      uses: ad-m/github-push-action@master
+      uses: ad-m/github-push-action@77c5b412c50b723d2a4fbc6d71fb5723bcd439aa # master on Jul 1, 2024
       with:
         branch: ${{ github.ref }}
 
     - name: Create Release Tag
-      uses: rickstaa/action-create-tag@v1
+      uses: rickstaa/action-create-tag@a1c7777fcb2fee4f19b0f283ba888afa11678b72 # v1.7.2
       with:
         tag: "v${{ steps.semver_parser.outputs.fullversion }}"
         message: "Release v${{ steps.semver_parser.outputs.fullversion }}"
 
     - name: GitHub Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
       with:
         generate_release_notes: true
         tag_name: v${{ steps.semver_parser.outputs.fullversion }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Mac OS X
 .DS_Store
+Thumbs.db
 
 # Node
 node_modules
@@ -10,3 +11,7 @@ npm-debug.log
 
 # Example
 example/node_modules
+
+# Environment variables
+.env
+.env.local

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":configMigration",
+    "docker:pinDigests"
+  ],
+  "packageRules": [
+    {
+      "matchDatasources": [
+        "npm"
+      ],
+      "minimumReleaseAge": "7 days"
+    },
+    {
+      "description": "Pin digests for GitHub Actions",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "pinDigests": true
+    },
+    {
+      "description": "Override to keep official GitHub Actions unpinned",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "pinDigests": false,
+      "matchPackageNames": [
+        "/^actions//"
+      ]
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": true
+  },
+  "osvVulnerabilityAlerts": true
+}


### PR DESCRIPTION
## JIRA Ticket

https://thetradedesk.atlassian.net/browse/OPENPASS-2786

## What does this PR solve?

Locks GitHub Actions dependencies with SHA digest pinning to achieve reproducible builds. Also:
- Explicitly set job permissions instead of implicit defaults.
- Remove persisted credentials where they are not needed (when no subsequent git operations performed)
- Set input to environment variables to avoid command injections
- Add items to .gitignore
- Add renovate.json config to pin/update third-party GitHub Actions